### PR TITLE
Feature: Add shadow casting mesh setting

### DIFF
--- a/addons/mm_plus_editor/nodes/mm_plus_3d.gd
+++ b/addons/mm_plus_editor/nodes/mm_plus_3d.gd
@@ -92,12 +92,14 @@ func load_multimesh() -> void:
 		_update_buffer(group_idx, buffer_map)
 
 func _add_visual_instance(group_idx : int, aabb : AABB) -> void:
-	var mesh : Mesh = data[group_idx].mesh_data.mesh
+	var mesh_data : MMPlusMesh = data[group_idx].mesh_data
+	var mesh : Mesh = mesh_data.mesh
 	var m_rid = RenderingServer.multimesh_create()
 	var i_rid : RID = RenderingServer.instance_create2(m_rid, get_world_3d().scenario)
 	RenderingServer.instance_set_transform(i_rid, global_transform)
 	RenderingServer.instance_set_custom_aabb(i_rid, aabb)
 	RenderingServer.multimesh_set_mesh(m_rid, mesh.get_rid())
+	RenderingServer.instance_geometry_set_cast_shadows_setting(i_rid, mesh_data.cast_shadow)
 	RenderingServer.instance_geometry_set_visibility_range(i_rid, 0.0, 100.0, 0.0, 0.0, RenderingServer.VISIBILITY_RANGE_FADE_DISABLED)
 	data[group_idx].multimesh_RID_map[aabb] = m_rid
 	data[group_idx].visual_instance_RID_map[aabb] = i_rid

--- a/addons/mm_plus_editor/resources/mm_plus_mesh.gd
+++ b/addons/mm_plus_editor/resources/mm_plus_mesh.gd
@@ -4,6 +4,7 @@ extends Resource
 
 @export var name : StringName = "" : set = _set_name
 @export var mesh : Mesh : set = _set_mesh
+@export var cast_shadow : RenderingServer.ShadowCastingSetting = RenderingServer.ShadowCastingSetting.SHADOW_CASTING_SETTING_ON : set = _set_shadow_cast
 ## Minimum space between this instance and another to avoid any overlap.
 @export var spacing : float = 0.5 : set = _set_spacing
 ## Offset applied to the transformation of the instance during placement.
@@ -32,6 +33,10 @@ func _set_name(new_name : StringName) -> void:
 
 func _set_mesh(new_mesh : Mesh) -> void:
 	mesh = new_mesh
+	emit_changed()
+
+func _set_shadow_cast(new_shadow_cast : RenderingServer.ShadowCastingSetting) -> void:
+	cast_shadow = new_shadow_cast
 	emit_changed()
 
 func _set_spacing(new_spacing : float) -> void:


### PR DESCRIPTION
# Feature
Whether an object casts shadows or not is handled on the mesh instance level in Godot. Being able to disable shadow casting is great for improving the performance, or sometimes even visuals of a multimesh. Especially when spawning many small meshes.

I've added a `RenderingServer.ShadowCastingSetting` variable to the MMPlusMesh and apply it on `_add_visual_instance`.

There are 2 things that could be improved on this PR:

1. The setting is rather verbose in the inspector, instead of `On` it says `Shadow Casting Setting On` (see video).
2. You need to reload the scene in order to apply changes (see video).

Problem 1. would probably require some custom inspector code. Problem 2. would need a way to update the instances if the mesh data changes.

# Video example
[Screencast_2026-01-16_10-54-28.webm](https://github.com/user-attachments/assets/97de2738-8e08-4951-8754-4f8dda66919e)

The error in this video is unrelated to this addon.
