### PR TITLE
FIX: Loosely fetch EditorInterface

### DIFF
--- a/addons/mm_plus_editor/resources/mm_plus_mesh.gd
+++ b/addons/mm_plus_editor/resources/mm_plus_mesh.gd
@@ -33,7 +33,9 @@ enum RotationMode {
 @export var data_mode : MMDataMode.Mode = MMDataMode.Mode.TransformOnly
 
 func update_thumbnail() -> void:
-	thumbnail = EditorInterface.make_mesh_previews([mesh], 64)[0]
+	if Engine.is_editor_hint():
+		var editor_interface = Engine.get_singleton("EditorInterface") # Avoids explicitly using the Singleton
+		thumbnail = editor_interface.make_mesh_previews([mesh], 64)[0]
 
 func _set_name(new_name : StringName) -> void:
 	name = new_name


### PR DESCRIPTION
PR to address issue https://github.com/gtibo/multimesh-plus/issues/13

## Problem

`EditorInterface` does not exist at runtime and thus the script fails to compile.

## Solution

Instead of hard referencing the class fetch it using a string reference.

I got this approach from a comment on the documentation https://docs.godotengine.org/en/4.4/classes/class_editorinterface.html